### PR TITLE
FlagSet: Visit()` workaround for persistent flags

### DIFF
--- a/action.go
+++ b/action.go
@@ -130,8 +130,10 @@ func (a action) Parse(cmd *cobra.Command) carapace.Action {
 		}
 		c.Setenv("C_VALUE", c.Value)
 
-		cmd.Flags().Visit(func(f *pflag.Flag) {
-			c.Setenv(fmt.Sprintf("C_FLAG_%v", strings.ToUpper(f.Name)), f.Value.String())
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { // VisitAll as Visit() skips changed persistent flags of parent commands
+			if f.Changed {
+				c.Setenv(fmt.Sprintf("C_FLAG_%v", strings.ToUpper(f.Name)), f.Value.String())
+			}
 		})
 
 		batch := carapace.Batch()

--- a/run.go
+++ b/run.go
@@ -19,11 +19,13 @@ type run string
 func (r run) parse() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		context := carapace.NewContext(args...)
-		cmd.Flags().Visit(func(f *pflag.Flag) {
-			if slice, ok := f.Value.(pflag.SliceValue); ok {
-				context.Setenv(fmt.Sprintf("C_FLAG_%v", strings.ToUpper(f.Name)), strings.Join(slice.GetSlice(), ","))
-			} else {
-				context.Setenv(fmt.Sprintf("C_FLAG_%v", strings.ToUpper(f.Name)), f.Value.String())
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { // VisitAll as Visit() skips changed persistent flags of parent commands
+			if f.Changed {
+				if slice, ok := f.Value.(pflag.SliceValue); ok {
+					context.Setenv(fmt.Sprintf("C_FLAG_%v", strings.ToUpper(f.Name)), strings.Join(slice.GetSlice(), ","))
+				} else {
+					context.Setenv(fmt.Sprintf("C_FLAG_%v", strings.ToUpper(f.Name)), f.Value.String())
+				}
 			}
 		})
 


### PR DESCRIPTION
Using `VisitAll()` instead of `Visit()` as the latter skips changed persistent flags.
This is due `Command.mergePersistenFlags` -> `FlagSet.AddFlagSet()`
only updating `formal/orderedFormal` and not `actual/orderedActual`.

related https://github.com/carapace-sh/carapace-bin/issues/2471#issuecomment-2318683463