### PR TITLE
add `carapace-spec-oclif` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ commands:
 - [carapace-spec-kong](https://github.com/carapace-sh/carapace-spec-kong) spec generation for alecthomas/kong
 - [carapace-spec-man](https://github.com/carapace-sh/carapace-spec-man) spec generation for manpages
 - [carapace-spec-urfavecli](https://github.com/carapace-sh/carapace-spec-urfavecli) spec generation for urfave/cli
+- [carapace-spec-oclif](https://github.com/cristiand391/oclif-carapace-spec-plugin) spec generation for oclif


### PR DESCRIPTION
Hey 👋🏼 

I wrote an oclif plugin to generate a carapace spec:
https://github.com/cristiand391/oclif-carapace-spec-plugin

oclif is a CLI framework for JS (full disclosure: my team maintains it but the plugin is my side project):
https://oclif.io/

it's not tied to any CLI-specific library so Salesforce, Heroku, Twilio, etc CLIs should be supported (I've been using it daily for Salesforce CLI)