### PR TITLE
run: release file lock

### DIFF
--- a/run.go
+++ b/run.go
@@ -150,6 +150,7 @@ func (r run) parseScript() func(cmd *cobra.Command, args []string) error {
 		if err := os.WriteFile(file.Name(), []byte(shebang.Script), 0600); err != nil {
 			return err
 		}
+		file.Close() // release lock
 
 		context := r.context(cmd, args)
 		scriptArgs := append(shebang.Args, file.Name())


### PR DESCRIPTION
fixes pwsh error on windows:
```
ObjectNotFound: The process cannot access the file
'C:\Users\steam\AppData\Local\Temp\carapace-spec_run_233841719.ps1'
because it is being used by another process
```
